### PR TITLE
Add ability to Group Libraries into types

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@ This component does not require, nor conflict with, the default [Emby](https://w
 | ssl | false | no | Whether or not to use SSL for Emby.
 | max | 5 | no | Max number of items in sensor.
 | use_backdrop | false | no | Defines whether to use the Backdrop Image, instead of the poster. (Great for using with the `fanart` display mode)
-| include| | no | The names or the Emby Libraries you want to include. If not specified, all libraries will be shown and this component will create one sensor per Library
+| include| | no | The names of the <strong>Emby Libraries</strong> you want to include. If not specified, all libraries will be shown and this component will create one sensor per Library. This is language specific.
+| group_libraries| false| no | This option generates only two sensors (emby_latest_movies / emby_latest_tv_shows), grouping all your movies and tv into seperate sensors despite library setup in Emby. </br>This is useful for when Emby has many libraries but you only want one sensor in Home Assistant 
 </br>
 
 **Do not just copy examples, please use config options above to build your own!**
 ### Sample for configuration.yaml:
-
+> This will add items from the 'Movies', 'Kids Movies' and 'Tv Shows' Libraries in Emby, creating a seperate sensor per library
 ```
 sensor:
 - platform: emby_upcoming_media
@@ -41,13 +42,59 @@ sensor:
   ssl: True
   max: 5
   use_backdrop: true
+  group_libraries: false
   include:
     - Movies
+    - Kids Movies
     - TV Shows
 ```
 
+> This will add all items Emby and create one sensor for movies (emby_latest_movies) and one for tv (emby_latest_tv_shows)
+```
+sensor:
+- platform: emby_upcoming_media
+  api_key: YOUR_EMBY_API_KEY
+  user_id: YOUR_EMBY_USER_ID
+  host: 192.168.1.4
+  port: 8096
+  ssl: True
+  max: 5
+  use_backdrop: true
+  group_libraries: true
+```
 ### Sample for ui-lovelace.yaml:
 
     - type: custom:upcoming-media-card
       entity: sensor.sensor.emby_latest_movies
       title: Latest Movies
+
+
+# Getting Information for the Plugin
+
+## api_key
+<ol>
+  <li>Navigate to the Emby Admin Dashboard (Cog in the top right)</li>
+  <li>Select <strong>Api Keys</strong> from the side menu</li>
+  <li>Select <strong>New Api Key</strong> from the top of the page</li>
+</ol>
+
+## user_id
+### Via Web Interface
+> This is just an example, make sure you get your own personal user_id
+<ol>
+  <li>Navigate to the Emby Admin Dashboard (Cog in the top right)</li>
+  <li>Select <strong>Users</strong> from the side menu</li>
+  <li>Select the user you plan to use in HA from the list</li>
+  <li>From the address bar you can get the user id </br>
+  <i>http://emby_host_ip:8096/emby/web/index.html#!/users/user?userId=<strong>527563753xfd422288a32198522f821a</strong></i>
+  </li>
+</ol>
+
+### Via API Interface
+<ol>
+  <li>Navigate to http://emby_host_ip:8096/emby/Users/Public</li>
+  <li>You will be provided a JSON response containing all the users details</li>
+  <li>Find the <strong>Name</strong> attribute for your user in the results</li>
+  <li>Next to the Name you will see an attribute name <strong>ServerId</strong></li>
+  <li>Next to the ServerId you will see <strong>Id</strong> - this is your user_id</li>
+</ol>

--- a/custom_components/emby_upcoming_media/client.py
+++ b/custom_components/emby_upcoming_media/client.py
@@ -25,6 +25,7 @@ class EmbyClient:
             url = "http{0}://{1}:{2}/Users/{3}/Views".format(
                 self.ssl, self.host, self.port, self.user_id
             )
+            _LOGGER.info("Making API call on URL %s", url)
             api = requests.get(url, timeout=10)
         except OSError:
             _LOGGER.warning("Host %s is not available", self.host)
@@ -42,7 +43,7 @@ class EmbyClient:
 
     def get_data(self, categoryId):
         try:
-            url = "http{0}://{1}:{2}/Users/{3}/Items/Latest?Limit={4}&Fields=CommunityRating,Studios,PremiereDate,Genres&ParentId={5}&api_key={6}&GroupItems=false".format(
+            url = "http{0}://{1}:{2}/Users/{3}/Items/Latest?Limit={4}&Fields=CommunityRating,Studios,PremiereDate,Genres,DateCreated&ParentId={5}&api_key={6}&GroupItems=false".format(
                 self.ssl,
                 self.host,
                 self.port,

--- a/custom_components/emby_upcoming_media/manifest.json
+++ b/custom_components/emby_upcoming_media/manifest.json
@@ -7,5 +7,5 @@
     "@gcorgnet"
   ],
   "requirements": [],
-  "version": "2021.3.1"
+  "version": "2021.5.1"
 }

--- a/info.md
+++ b/info.md
@@ -13,4 +13,5 @@ This component does not require, nor conflict with, the default [Emby](https://w
 | ssl | false | no | Whether or not to use SSL for Emby.
 | max | 5 | no | Max number of items in sensor.
 | use_backdrop | false | no | Defines whether to use the Backdrop Image, instead of the poster. (Great for using with the `fanart` display mode)
-| include| | no | The names or the Emby Libraries you want to include. If not specified, all libraries will be shown and this component will create one sensor per Library
+| include| | no | The names of the <strong>Emby Libraries</strong> you want to include. If not specified, all libraries will be shown and this component will create one sensor per Library. This is language specific.
+| group_libraries| false| no | This option generates only two sensors (emby_latest_movies / emby_latest_tv_shows), grouping all your movies and tv into seperate sensors despite library setup in Emby. </br>This is useful for when Emby has many libraries but you only want one sensor in Home Assistant 


### PR DESCRIPTION
Updated ReadME and Info to include new information.

Group Libraries gives the ability to create one sensor per CollectionType rather than per library so Home Assistant can have an overview of all new media and is not required to have one per library

Option is disabled by default.

Hoping this should be able to also close off the below for you
#9 
#11 
#15 