### PR TITLE
Add dependency for 2021.6 core release

### DIFF
--- a/custom_components/emby_upcoming_media/manifest.json
+++ b/custom_components/emby_upcoming_media/manifest.json
@@ -6,6 +6,6 @@
   "codeowners": [
     "@gcorgnet"
   ],
-  "requirements": [],
-  "version": "2021.3.1"
+  "requirements": ["python-dateutil"],
+  "version": "0.3.5"
 }


### PR DESCRIPTION
2021.6 changed the way core handles python-dateutil (it was removed), so it must be defined explicitly as a required package.

Context: https://developers.home-assistant.io/blog/2021/05/07/switch-pytz-to-python-dateutil/